### PR TITLE
Update influxdb.R

### DIFF
--- a/R/influxdb.R
+++ b/R/influxdb.R
@@ -20,7 +20,7 @@ NULL
 influxdb_query <- function(host, port, username, password, database, query,
                         time_precision=c("s", "m", "u")) {
   response <- GET(
-    "", scheme = "http", host = host, port = port,
+    "", scheme = "http", hostname = host, port = port,
     path = sprintf("db/%s/series", URLencode(database)),
     query = list(
       u = username,


### PR DESCRIPTION
The call to GET currently returns 'Error in function (type, msg, asError = TRUE)  : couldn't connect to host'.
I traced this to the named arguments to GET. One of the lower level functions is looking for the field 'hostname', not host.
After I renamed the arg in GET to hostname = host, the call to influx worked..I am using httr 0.3, based on the help page. I am not sure if this is a version specific issue in httr.
